### PR TITLE
Optimize `docker-compose.yml`

### DIFF
--- a/edge/docker-compose.yml
+++ b/edge/docker-compose.yml
@@ -1,32 +1,36 @@
-version: "3.8"
 services:
   ecosort-edge:
     image: pdec5504/ecosort-edge:latest
     container_name: ecosort-edge
-    restart: always
-    stdin_open: true
-    tty: true
+    restart: unless-stopped
     network_mode: "host"
-    privileged: true
+    devices:
+      - "/dev/video0:/dev/video0"
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - ~/.Xauthority:/root/.Xauthority:ro
-      - ./:/app
-    devices:
-      - "/dev/video0:/dev/video0"
+    env_file:
+      - .env
     environment:
-      - API_URL=https://ecosort-ai-nine.vercel.app/api/v1/trash-events
-      - BIN_ID=smart_bin_01
-      - CAMERA_SOURCE=0
       - DISPLAY=:0
       - XAUTHORITY=/root/.Xauthority
+    loggin:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   watchtower:
     image: containrrr/watchtower
     container_name: watchtower
-    restart: always
+    restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - DOCKER_API_VERSION=1.41
     command: --interval 60 --cleanup
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "5m"
+        max-file: "3"


### PR DESCRIPTION
Este PR foca no hardening (fortalecimento) e na otimização do docker-compose.yml. As alterações garantem maior segurança, protegem a integridade do hardware da Raspberry Pi (SD Card) e preparam a arquitetura para o funcionamento perfeito do pipeline de Continuous Deployment (CD) via Watchtower.

## Principais Alterações

### Desacoplamento de Código

Remoção do volume local `(./:/app)`: O container agora roda estritamente a imagem compilada e puxada do Docker Hub. Isso previne que a Raspberry Pi continue executando código legado local após o Watchtower atualizar a imagem.

### Implementação do Padrão Twelve-Factor (Gestão de Segredos)

- Injeção direta de variáveis sensíveis foi removida do bloco `environment`
- Implementação do caminho `env_file: .env` para carregar de forma segura dados como `API_URL`, `BIN_ID` e `CAMERA_SOURCE`, mantendo apenas configurações estritas do SO (DISPLAY e XAUTHORITY) no compose.

### Log Rotation

- Problema: O Docker armazenava logs infinitamente, o que acabaria por esgotar o armazenamento do SD Card em poucas semanas de operação 24/7.
- Solução: Implementação de políticas de retenção de logs (max-size: 10m e max-file: 3) para os serviços ecosort-edge e watchtower, garantindo que apenas os logs mais recentes são mantidos.

### Política de Reinicialização Segura

Alteração da política de `restart: always` para `restart: unless-stopped`. Isso garante alta disponibilidade em caso de falha de energia ou crash, mas respeita o comando de desligamento manual do administrador (docker compose stop), evitando que contentores defeituosos subam sozinhos após um reboot.

### Hardening e Limpeza de Debug

- Remoção da flag privileged: true, reduzindo a superfície de ataque (o acesso a hardware agora é feito de forma explícita via devices: ["/dev/video0:/dev/video0"]).
- Remoção das flags tty e stdin_open (peso morto, já que o sistema agora opera em modo Headless).
- Remoção da tag version: "3.8" (obsoleta nas versões modernas do Docker Compose).

A lixeira inteligente agora opera com uma infraestrutura significativamente mais leve, resiliente a falhas de armazenamento e com os seus segredos devidamente protegidos, completando a fundação de infraestrutura na Borda (Edge).